### PR TITLE
chore: Update flake.lock and refactor flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1727854478,
+        "narHash": "sha256-/odH2nUMAwkMgOS2nG2z0exLQNJS4S2LfMW0teqU7co=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "5f58871c9657b5fc0a7f65670fe2ba99c26c1d79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Updated `flake.lock` to reflect the latest changes from the `pre-commit-hooks.nix` repository.
- Refactored `flake.nix` to improve readability and maintainability:
  - Removed redundant newlines for better consistency.
  - Simplified the `devShells` definition by using a let-in expression for `pre-commit-check`.
  - Added comments for better clarity.
  - Ensured the `formatter` attribute is correctly defined.