### PR TITLE
Integrate sops-nix for secrets management and add personal cloud conf…

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,9 @@
+keys:
+  - &admin_michael age1g0hp53jqntn6xmd73kd9wx33gst5yvz6gzuwt3t8yx2rvr08h5mqey899s
+  - &server_michael age1h464yfcqxe39qlgxvte2yf5wgpjc0wmtdv7luadr9lxnn5fwl5aq7fjyxq
+creation_rules:
+  - path_regex: secrets/[^/]+\.(yaml|json|env|ini)$
+    key_groups:
+      - age:
+          - *admin_michael
+          - *server_michael

--- a/flake.lock
+++ b/flake.lock
@@ -335,16 +335,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727802920,
-        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
-        "owner": "nixos",
+        "lastModified": 1728834104,
+        "narHash": "sha256-KOLge7zCivtuaBJUMd2KwOILc0JEuIC3ER2hv5rBv0Y=",
+        "owner": "michaelvanstraten",
         "repo": "nixpkgs",
-        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
+        "rev": "375e0729f015ab48a6c2831c2a2dffd6de3bc179",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "michaelvanstraten",
+        "ref": "add-godns-service",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -381,6 +381,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1728156290,
+        "narHash": "sha256-uogSvuAp+1BYtdu6UWuObjHqSbBohpyARXDWqgI12Ss=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "17ae88b569bb15590549ff478bab6494dde4a907",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -433,7 +449,29 @@
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "nixpkgs-firefox-darwin": "nixpkgs-firefox-darwin",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "sops-nix": "sops-nix"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1728345710,
+        "narHash": "sha256-lpunY1+bf90ts+sA2/FgxVNIegPDKCpEoWwOPu4ITTQ=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "06535d0e3d0201e6a8080dd32dbfde339b94f01b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     };
 
     nixpkgs = {
-      url = "github:nixos/nixpkgs/nixos-unstable";
+      url = "github:michaelvanstraten/nixpkgs/add-godns-service";
     };
 
     nixpkgs-firefox-darwin = {
@@ -45,6 +45,11 @@
 
     pre-commit-hooks = {
       url = "github:cachix/git-hooks.nix";
+    };
+
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 

--- a/nixosConfigurations/default.nix
+++ b/nixosConfigurations/default.nix
@@ -1,18 +1,35 @@
-{ nixpkgs, ... }@args:
+{ nixpkgs, sops-nix, ... }@args:
 let
   inherit (nixpkgs.lib) nixosSystem;
 
+  make-disk-image = import "${nixpkgs}/nixos/lib/make-disk-image.nix";
+
   defaultArgs = {
     specialArgs = {
-      make-disk-image = import "${nixpkgs}/nixos/lib/make-disk-image.nix";
+      inherit make-disk-image;
     } // args;
   };
-
 in
 {
-  h2946065 = nixosSystem (defaultArgs // { modules = [ ./hosts/h2946065/configuration.nix ]; });
+  h2946065 = nixosSystem (
+    defaultArgs
+    // {
+      modules = [
+        ../secrets
+        ./hosts/h2946065/configuration.nix
+        sops-nix.nixosModules.sops
+      ];
+    }
+  );
 
   rack-01-k8s-master-nuc-01 = nixosSystem (
-    defaultArgs // { modules = [ ./hosts/rack-01/k8s-master-nuc-01.nix ]; }
+    defaultArgs
+    // {
+      modules = [
+        ../secrets
+        ./hosts/rack-01/k8s-master-nuc-01.nix
+        sops-nix.nixosModules.sops
+      ];
+    }
   );
 }

--- a/nixosConfigurations/hosts/h2946065/configuration.nix
+++ b/nixosConfigurations/hosts/h2946065/configuration.nix
@@ -1,11 +1,12 @@
 { nixosModules, pkgs, ... }:
 {
   imports = with nixosModules; [
+    ./virtual-disk-MBR.nix
     hardware.libvirtd
     nix
+    personal-cloud
     ssh
     users
-    ./virtual-disk-MBR.nix
   ];
 
   networking.hostName = "h2946065";
@@ -25,7 +26,6 @@
 
   boot.kernel.sysctl = {
     "net.ipv4.ip_unprivileged_port_start" = 80;
-
   };
 
   users.users.michael.extraGroups = [ "docker" ];

--- a/nixosConfigurations/hosts/rack-01/k8s-master-nuc-01.nix
+++ b/nixosConfigurations/hosts/rack-01/k8s-master-nuc-01.nix
@@ -4,6 +4,7 @@
     format.raw-efi
     hardware.intel-nuc
     nix
+    personal-cloud
     roles.k8s-master
     ssh
     users

--- a/nixosModules/personal-cloud.nix
+++ b/nixosModules/personal-cloud.nix
@@ -1,0 +1,26 @@
+{ config, ... }:
+{
+  networking.domain = "vanstraten.cloud";
+
+  services.godns = {
+    enable = true;
+    configPath = config.sops.templates."godns-config.yaml".path;
+  };
+
+  sops.templates."godns-config.yaml".content = # yaml
+    ''
+      provider: Cloudflare
+      login_token: "${config.sops.placeholder.cloudflare-api-token}"
+      domains:
+        - domain_name: "${config.networking.domain}"
+          sub_domains:
+            - "${config.networking.hostName}"
+      ipv6_urls:
+        - https://api6.ipify.org
+        - https://api-ipv6.ip.sb/ip
+        - https://ip2location.io/ip
+        - https://v6.ipinfo.io/ip
+      ip_type: IPv6
+      interval: 300
+    '';
+}

--- a/nixosModules/services/godns.nix
+++ b/nixosModules/services/godns.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.godns;
+
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+in
+{
+  options.services.godns = {
+    enable = mkEnableOption "GoDNS Service";
+
+    package = mkPackageOption pkgs "godns" { };
+
+    configPath = mkOption {
+      type = types.path;
+      description = "Path to the configuration file for godns.";
+      example = "/etc/godns/config.json";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.godns = {
+      description = "GoDNS Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} -c ${cfg.configPath}";
+        Restart = "always";
+        KillMode = "process";
+        RestartSec = "2s";
+      };
+    };
+  };
+}

--- a/secrets/cluster-wide.yaml
+++ b/secrets/cluster-wide.yaml
@@ -1,0 +1,30 @@
+cloudflare-api-token: ENC[AES256_GCM,data:R9b64oItxvQm6FYRS5vK8zzg3ZfY/7DA1ZI+cZOGTgelk8UhtFo4dQ==,iv:2K9UwW6/x0gM1FY/PUu5NqQZCesyaUiHnHc0k8P0lhg=,tag:Orf3BqUeh2Leh/4bQ6sxEg==,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1g0hp53jqntn6xmd73kd9wx33gst5yvz6gzuwt3t8yx2rvr08h5mqey899s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6djdJcWhadDdiQTFKKy82
+        WHc1MUN0aHJuSmJoTmJ5UEd5VUlDL0VBd1djCkVzdDYySFA5SDYycXI0VythSWNz
+        Ymk4SCtKZFE1L0xhQ2pNdG9nbElybDgKLS0tIHFPL2NMZ215SVFha1VJZnR3dm1p
+        cGVQQWRKeFVoVXFhdk5FMzVKQ3JuUkEKFnIe3qzer43AsSPdah0Q15GW2FpuZ0wZ
+        IdwWpF900gp643/laEEEKtXFEUBbNlRAvyPf1ehrxt8qM28qLbuxUQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1h464yfcqxe39qlgxvte2yf5wgpjc0wmtdv7luadr9lxnn5fwl5aq7fjyxq
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTM2tTZ1lJWFpsdlBobUFs
+        MGFBc1p3V2huYkJVaGRTS2tvTXpzN0VGc1NnCmpaMVlGNUV0dzkwTVR0dWozMnpJ
+        WXVtaDQwcURiU0huZW1vWWZnRlpRYVkKLS0tIDdwOW5oV3c0U3J5WmxIb3k1NkRn
+        SEkyL0Y5MUsvOHZtNkRHNktSa00wRFEKB0Qldf68bi+s5zHtaDUToHlcxXyqvfM0
+        pZwKxTBFnRmzL6ijz4SuiY5+WpHQjYDyEgTfxCqIeqwCDr+EMg6VTA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-10-13T11:09:32Z"
+  mac: ENC[AES256_GCM,data:OV4RaFl/uIW8K06EUq0jdQgvwM6QyRPN4FkmILtfy7Pyi5Z/RMVSMhCe6jDmqDiNSmEeGkq4N8EPMXxuLInXv4a4pf2l3K1HULXxwRW5R6gb/aj37hwzRBGfMWoG3/sKIghGwHYrtxaJeU95kgPK4jgHgy1IW/3zfc6mpNM90pM=,iv:42+J1e/fqzCdJTIHDOWI5MyrLUuWN3Lllg0B6zXPUo0=,tag:jPcm859ShtLXyMhNOqY2hg==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.0

--- a/secrets/default.nix
+++ b/secrets/default.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  sops.secrets.cloudflare-api-token = {
+    sopsFile = ./cluster-wide.yaml;
+  };
+}


### PR DESCRIPTION
…iguration

- Added `.sops.yaml` for configuring sops encryption keys and rules.
- Updated `flake.lock` to include `sops-nix` and `nixpkgs-stable` references.
- Modified `flake.nix` to include `sops-nix` as an input.
- Updated `nixosConfigurations/default.nix` to include `sops-nix` module and secrets configuration.
- Added `personal-cloud.nix` module for personal cloud services configuration.
- Added `godns.nix` service module for GoDNS service configuration.
- Added `cluster-wide.yaml` for storing encrypted secrets.
- Added `secrets/default.nix` for sops secrets configuration.