### PR TITLE
Add environment module for shell configuration and aliases; remove in…

### DIFF
--- a/darwinConfigurations/hosts/mozilla-macbook-pro.nix
+++ b/darwinConfigurations/hosts/mozilla-macbook-pro.nix
@@ -1,6 +1,7 @@
 { darwinModules, pkgs, ... }:
 {
   imports = with darwinModules; [
+    environment
     home-manager
     nix
     packages

--- a/darwinConfigurations/hosts/personal-macbook-pro.nix
+++ b/darwinConfigurations/hosts/personal-macbook-pro.nix
@@ -1,6 +1,7 @@
 { darwinModules, pkgs, ... }:
 {
   imports = with darwinModules; [
+    environment
     home-manager
     nix
     packages

--- a/homeConfigurations/mozilla.nix
+++ b/homeConfigurations/mozilla.nix
@@ -23,13 +23,7 @@
 
   xdg.enable = true;
   home = {
-    sessionVariables = {
-      EDITOR = "nvim";
-    };
     stateVersion = "24.05";
-    shellAliases = {
-      ls = "eza";
-    };
 
     packages = with pkgs; [
       wget
@@ -47,8 +41,6 @@
   };
 
   programs = {
-    eza.enable = true;
-
     sesh.enable = true;
 
     thefuck.enable = true;

--- a/homeConfigurations/personal.nix
+++ b/homeConfigurations/personal.nix
@@ -23,13 +23,7 @@
 
   xdg.enable = true;
   home = {
-    sessionVariables = {
-      EDITOR = "nvim";
-    };
     stateVersion = "24.05";
-    shellAliases = {
-      ls = "eza";
-    };
 
     packages = with pkgs; [
       wget
@@ -47,8 +41,6 @@
   };
 
   programs = {
-    eza.enable = true;
-
     sesh.enable = true;
 
     thefuck.enable = true;

--- a/modules/darwin/environment.nix
+++ b/modules/darwin/environment.nix
@@ -1,0 +1,31 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+{
+  environment = {
+    shellAliases = {
+      c = "clear";
+      e = "$EDITOR";
+      l = "ls";
+      la = "ls -a";
+      ll = "ls -l";
+      lla = "ls -la";
+      ls = "eza";
+      tree = "eza --tree";
+    };
+
+    shells = lib.mapAttrsToList (_: user: user.shell) config.users.users;
+
+    systemPackages = [
+      pkgs.eza
+      pkgs.neovim
+    ];
+
+    variables = {
+      EDITOR = "nvim";
+    };
+  };
+}

--- a/modules/darwin/shells.nix
+++ b/modules/darwin/shells.nix
@@ -1,7 +1,5 @@
-{ config, lib, ... }:
+{ ... }:
 {
-  environment.shells = lib.mapAttrsToList (_: user: user.shell) config.users.users;
-
   programs.bash.enable = true;
   programs.fish.enable = true;
   programs.zsh.enable = true;

--- a/modules/home-manager/shells.nix
+++ b/modules/home-manager/shells.nix
@@ -4,12 +4,7 @@
     enable = true;
 
     shellAbbrs = {
-      c = "clear";
       gc = "git clone";
-      l = "ls";
-      la = "ls -a";
-      ll = "ls -l";
-      lla = "ls -la";
       tn = "tmux new -s (pwd | sed \"s/.*\///g\")";
     };
 


### PR DESCRIPTION
…line session variables from home configurations.

- Introduced a new `environment` module that defines shell aliases and environment variables.
- Updated `mozilla-macbook-pro.nix` and `personal-macbook-pro.nix` to import the new `environment` module.
- Cleaned up `homeConfigurations` by removing session variables and shell aliases that are now handled in the `environment` module.
- Adjusted `darwin/shells.nix` to streamline shell configuration.